### PR TITLE
Added useTranslate3d prop

### DIFF
--- a/src/default-props.js
+++ b/src/default-props.js
@@ -38,6 +38,7 @@ var defaultProps = {
     edgeEvent: null,
     init: null,
     swipeEvent: null,
+    useTranslate3d: true,
     // nextArrow, prevArrow are react componets
     nextArrow: null,
     prevArrow: null

--- a/src/mixins/trackHelper.js
+++ b/src/mixins/trackHelper.js
@@ -22,11 +22,20 @@ export var getTrackCSS = function(spec) {
     trackWidth = (spec.slideCount + 2*spec.slidesToShow) * spec.slideWidth;
   }
 
+  var translateMethod, tz;
+  if (spec.useTranslate3d) {
+    translateMethod = 'translate3d';
+    tz = ', 0px';
+  } else {
+    translateMethod = 'translate';
+    tz = '';
+  }
+
   var style = {
     opacity: 1,
     width: trackWidth,
-    WebkitTransform: 'translate(' + spec.left + 'px, 0px)',
-    transform: 'translate(' + spec.left + 'px, 0px)',
+    WebkitTransform: translateMethod + '(' + spec.left + 'px, 0px' + tz + ')',
+    transform: translateMethod + '(' + spec.left + 'px, 0px' + tz + ')',
     transition: '',
     WebkitTransition: '',
     msTransform: 'translateX(' + spec.left + 'px)'


### PR DESCRIPTION
Slider defaults to using translate3d, unless passed in a prop

ie:
`<Slider useTranslate3d={false}>`

Checked on ps4 and looks like not passing in the useTranslate3d prop works, and passing in false breaks the app.